### PR TITLE
修复有时右键菜单丢失

### DIFF
--- a/background/index.js
+++ b/background/index.js
@@ -1,6 +1,11 @@
 /* global chrome */
 
-(function() {
+//(function() {
+
+  //点击插件的图标重启右键菜单
+  chrome.browserAction.onClicked.addListener(function(tab) {
+    initContextMenu()
+  })
   var defaultRules = window.defaultRules
   var appData
 
@@ -162,4 +167,4 @@
   })
 
   initContextMenu()
-})()
+//})()


### PR DESCRIPTION
可能是匿名函数导致的右键菜单丢失，于是去除了外层的匿名函数。不清楚上面的方法能否解决问题，于是加入点击图标重启右键菜单的功能。